### PR TITLE
Add missing HttpResponse import

### DIFF
--- a/factory_system/inventory/views.py
+++ b/factory_system/inventory/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.contrib.contenttypes.models import ContentType
+from django.http import HttpResponse
 from .models import Inventory
 
 def inventory_list_view(request):


### PR DESCRIPTION
## Summary
- add the HttpResponse import in `inventory/views.py`

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_6863d41d81848332aa63825130582fbc