### PR TITLE
Fix CSV import postcode argument

### DIFF
--- a/factory_system/customers/views.py
+++ b/factory_system/customers/views.py
@@ -147,7 +147,7 @@ def import_customers_csv(request):
                     address_1=row.get('Address 1', ''),
                     address_2=row.get('Address 2', ''),
                     city=row.get('City', ''),
-                    post_code=row.get('Post Code', ''),
+                    postcode=row.get('Post Code', ''),
                     notes=row.get('Notes', ''),
                     is_active=(row.get('Is Active', '').lower() == 'yes'),
                     created_by=request.user


### PR DESCRIPTION
## Summary
- fix CSV import by using `postcode` field name

## Testing
- `python manage.py test` *(fails: connection to localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_6863d41b84d4833281f18e1c6fdff911