### PR TITLE
Update order creation test for production stage

### DIFF
--- a/factory_system/factory_system/settings_test.py
+++ b/factory_system/factory_system/settings_test.py
@@ -1,0 +1,8 @@
+from .settings import *
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}

--- a/factory_system/orders/tests.py
+++ b/factory_system/orders/tests.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from django.contrib.auth.models import User
 from customers.models import Customer
 from orders.models import Order
+from production.models import ProductionStage
 
 
 class OrderCreateViewTests(TestCase):
@@ -23,14 +24,17 @@ class OrderCreateViewTests(TestCase):
             "reference": "REF123",
             "delivery_date": "2025-05-01",
             "order_type": "KITCHEN",
-            "status": "PENDING",
+            "priority": "MEDIUM",
+            "status": "NO_PAPERWORK",
             "robes": 3,
             "cabs": 5,
             "panels": 7,
             "owner": self.user.id,
+            "send_to_production": True,
         })
 
         self.assertEqual(response.status_code, 302)  # Redirects after success
         self.assertEqual(Order.objects.count(), 1)
         order = Order.objects.first()
         self.assertEqual(order.name, "Test Order")
+        self.assertTrue(ProductionStage.objects.filter(order=order).exists())


### PR DESCRIPTION
## Summary
- include `send_to_production` in order creation tests
- verify that a `ProductionStage` is created when posting an order
- add test settings using SQLite for CI environments

## Testing
- `python factory_system/manage.py test orders.tests.OrderCreateViewTests.test_order_create_view --verbosity 2 --settings=factory_system.settings_test`

------
https://chatgpt.com/codex/tasks/task_e_6863d41e19f0833298840ea1a76f4b33